### PR TITLE
Unify `fix-debug` scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,6 @@
     },
     "scripts": {
         "test": "phpunit",
-        "test-debug-phpstorm": "XDEBUG_CONFIG=\"idekey=PHPSTORM\" phpunit",
-        "test-debug-netbeans": "XDEBUG_CONFIG=\"idekey=netbeans-xdebug\" phpunit"
+        "test-debug": "XDEBUG_CONFIG=\"idekey=my-xdebug-key\" phpunit"
     }
 }


### PR DESCRIPTION
Unnecessary to have a single script for each IDE. Just set the xdebug key in your IDE to `my-xdebug-key`.